### PR TITLE
Avoid jinja2 in when warnings

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 # Copyright 2017, Logan Vig <logan2211@gmail.com>
+# Copyright 2017, Major Hayden <major@mhtx.net>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +15,7 @@
 # limitations under the License.
 
 # Can be used to completely disable the role's handler actions
-haproxy_management: "{{ haproxy_hosts | default([]) | length > 0 }}"
+haproxy_management: yes 
 
 # Selection of load balancer hosts to manage endpoints on
 haproxy_group: haproxy

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 # Copyright 2017, Logan Vig <logan2211@gmail.com>
+# Copyright 2017, Major Hayden <major@mhtx.net>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,5 +27,7 @@
     weight: "{{ haproxy_weight | default(omit) }}"
   delegate_to: "{{ item }}"
   with_items: "{{ haproxy_hosts }}"
-  when: haproxy_management | bool
+  when:
+    - haproxy_hosts | default([]) | length > 0
+    - haproxy_management | bool
   listen: Manage LB


### PR DESCRIPTION
This patch adjusts the handler to use the jinja2 statement directly
rather than using a variable with delimiters. This will hopefully
avoid the warning we currently see in OpenStack-Ansible:

    [WARNING]: when statements should not include jinja2 templating
    delimiters such as {{ }} or {% %}.
    Found: {{ groups['haproxy'] | default([]) | length > 0 }}